### PR TITLE
fix user id when creating spaces

### DIFF
--- a/api/Collection.ts
+++ b/api/Collection.ts
@@ -178,7 +178,7 @@ class Collection extends Data<ICollection> {
     const matched: Page[] = [], page_ids: string[] = [];
     await this.initializeCache();
     for (let [_, page] of this.cache.block)
-      if (page.type === "page" && page.parent_id === this.id) page_ids.push(page.id)
+      if (page?.type === "page" && page.parent_id === this.id) page_ids.push(page.id)
 
     if (Array.isArray(args)) {
       for (let index = 0; index < args.length; index++) {

--- a/api/NotionUser.ts
+++ b/api/NotionUser.ts
@@ -96,7 +96,7 @@ class NotionUser extends Data<INotionUser> {
           interval: this.interval,
           token: this.token,
           cache: this.cache,
-          user_id: space.permissions[0].user_id,
+          user_id: this.user_id,
           shard_id: space.shard_id,
           space_id: space.id,
           logger: this.logger

--- a/api/Space.ts
+++ b/api/Space.ts
@@ -275,7 +275,7 @@ export default class Space extends Data<ISpace> {
     multiple = multiple ?? true;
     await this.initializeCache();
     this.initializeChildData();
-    const data = this.getCachedData(), collections: Collection[] = [], collection_ids = (((data[this.child_path] as string[]).map((id) => this.cache.block.get(id) as TRootPage)).filter((cvp) => cvp.type === "collection_view_page") as IRootCollectionViewPage[]).map(cvp => cvp.collection_id);
+    const data = this.getCachedData(), collections: Collection[] = [], collection_ids = (((data[this.child_path] as string[]).map((id) => this.cache.block.get(id) as TRootPage)).filter((cvp) => cvp?.type === "collection_view_page") as IRootCollectionViewPage[]).map(cvp => cvp.collection_id);
 
     if (Array.isArray(args)) {
       for (let index = 0; index < args.length; index++) {


### PR DESCRIPTION
There's two fixes here:
1) I'm assuming we can rely on `this.user_id` to be set when retrieving spaces, and using that instead of looking at the first user with permissions. 
2) I was running into issues related to private pages which are undefined, so made it optional when filtering them by type.