### PR TITLE
FEAT: add ability to insert links into context

### DIFF
--- a/utils/inlineBlocks.ts
+++ b/utils/inlineBlocks.ts
@@ -174,6 +174,11 @@ class chunk extends Colors {
     this.text[this.text.length - 1][1].push(["h", color]);
     return new chunk(this.text);
   }
+
+  linkTo(url: string) {
+    this.text[this.text.length - 1][1].push(["a", url]);
+    return new chunk(this.text);
+  }
 }
 
 export function inlineText(title: string) {


### PR DESCRIPTION
So now you can do, for example:
```
inlineText('Link to discussion: ').add('#' + slackChannel).linkTo(linkToSlack)
```