### PR TITLE
add .npmignore so that npm can package compiled code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ feature.md
 .netlify
 /docs/build
 /workflows/env.ts
+nishan-1.0.0.tgz
 
 # OSX files
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ feature.md
 .netlify
 /docs/build
 /workflows/env.ts
+
+# OSX files
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ feature.md
 .netlify
 /docs/build
 /workflows/env.ts
-nishan-1.0.0.tgz
+**/*.tgz
 
 # OSX files
 .DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -1,11 +1,10 @@
 # Node files
-node_modules
 package-lock.json
-nishan-1.0.0.tgz
+**/*.tgz
 
 # source files
-*.ts
-!*.d.ts
+**/*.ts
+!**/*.d.ts
 /api
 /docs
 /public

--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,11 @@
 # Node files
 node_modules
 package-lock.json
+nishan-1.0.0.tgz
 
 # source files
 *.ts
+!*.d.ts
 /api
 /docs
 /public

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,13 @@
+# Node files
+node_modules
+package-lock.json
+
+# source files
+*.ts
+/api
+/docs
+/public
+/types
+/utils
+/workflows
+/.github


### PR DESCRIPTION
I'm already deploying some code using your library, but I needed to get `npm pack` to work. By default, I think it uses whatever is in `.gitignore`.

(I'm deploying via a tarball that I have uploaded, because my CI system doesn't have access to Git). 