### PR TITLE
FEAT: transpile to es2019 to support node 12

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
       "dom",
     ],
     "module": "commonjs",
-    "target": "ESNext",
+    "target": "es2019",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Use of nullish coalescing was causing the library not to work, forcing me to upgrade. I don't think it hurts to transpile to an older version, and more people might be able to re-use this code who haven't or can't update quickly. Also, I think `esnext` is a moving target of specs, which isn't ideal for a library imo. Tested on node.js v12.20.0.
