### PR TITLE
FIX: Add created and last_edited fields when creating a page

### DIFF
--- a/api/Block.ts
+++ b/api/Block.ts
@@ -27,8 +27,8 @@ class Block<T extends TBlock, A extends TBlockInput> extends Data<T> {
   /**
    * Duplicate the current block
    * @param infos Array of objects containing information regarding the position and id of the duplicated block
-   * @param execute Boolean to indicate whether to execute the operation or add it for batching 
-   * @returns A block map 
+   * @param execute Boolean to indicate whether to execute the operation or add it for batching
+   * @returns A block map
    */
 
   async duplicate(infos: { position: RepositionParams, id?: string }[], execute?: boolean) {

--- a/api/Data.ts
+++ b/api/Data.ts
@@ -844,6 +844,7 @@ export default class Data<T extends TData> extends Operations {
         else if (content.type === "page") {
           if (content.contents)
             await traverse(content.contents, $block_id, "block");
+          const current_time = Date.now();
           ops.push(Operation.block.update($block_id, [], {
             is_template: (content as any).is_template && parent_table === "collection",
             id: $block_id,
@@ -854,6 +855,12 @@ export default class Data<T extends TData> extends Operations {
             parent_table,
             alive: true,
             permissions: [{ type: content.isPrivate ? 'user_permission' : 'space_permission', role: 'editor', user_id: this.user_id }],
+            created_time: current_time,
+            created_by_id: this.user_id,
+            created_by_table: 'notion_user',
+            last_edited_time: current_time,
+            last_edited_by_id: this.user_id,
+            last_edited_by_table: 'notion_user'
           }))
           block_map[type].push(await this.createClass(content.type, $block_id));
         }


### PR DESCRIPTION
I noticed these fields are used in createBlock(), and that that method isn't used anywhere. You may want to add them for other types of blocks? Page is the one that really matters to me.